### PR TITLE
fix: use correct styles for table header cells (th) vs data cells (td)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,18 +229,15 @@ export const initRenderer = ({
 
   customRenderer.tablecell = (content, flags) => {
     const type = flags.header ? "th" : "td";
-      const tag = flags.align
-        ? `<${type} align="${flags.align}"${
-            parseCssInJsToInlineCss(finalStyles.td) !== ""
-              ? ` style="${parseCssInJsToInlineCss(finalStyles.td)}"`
-              : ""
-          }>`
-        : `<${type}${
-            parseCssInJsToInlineCss(finalStyles.td) !== ""
-              ? ` style="${parseCssInJsToInlineCss(finalStyles.td)}"`
-              : ""
-          }>`;
-      return tag + content + `</${type}>\n`;
+    const styles = parseCssInJsToInlineCss(
+      finalStyles[flags.header ? "th" : "td"]
+    );
+    const tag = flags.align
+      ? `<${type} align="${flags.align}"${
+          styles !== "" ? ` style="${styles}"` : ""
+        }>`
+      : `<${type}${styles !== "" ? ` style="${styles}"` : ""}>`;
+    return tag + content + `</${type}>\n`;
   }
 
   customRenderer.tablerow = (content) => {


### PR DESCRIPTION
Previously, both th and td elements were using finalStyles.td, causing header cell styles to be ignored. 
This fix properly uses finalStyles.th for header cells and finalStyles.td for data cells.